### PR TITLE
Fix getdim bug for 0 dim functions

### DIFF
--- a/src/functions/functions.jl
+++ b/src/functions/functions.jl
@@ -110,7 +110,7 @@ function (f::VectorOfFunctions)(args...; kwargs...)
 end
 
 function getdim(c::VectorOfFunctions)
-    @assert length(c.fs) > 0
+    length(c.fs) == 0 && return 0
     return sum(getdim, c.fs)
 end
 


### PR DESCRIPTION
This PR fixes a bug that triggers an error when `getdim` is called on a 0 dim function.